### PR TITLE
added the option for a sessioncookie in heiseBridge

### DIFF
--- a/bridges/HeiseBridge.php
+++ b/bridges/HeiseBridge.php
@@ -103,6 +103,11 @@ class HeiseBridge extends FeedExpander
             'required' => false,
             'title' => 'Specify number of full articles to return',
             'defaultValue' => 5
+        ],
+        'sessioncookie' => [
+            'name' => 'Session Cookie',
+            'required' => false,
+            'title' => 'If you have a heise+ subscription, you can enter your cookie (ssohls) here to get the full heise+ articles. By default the cookie is one year valid.',
         ]
     ]];
     const LIMIT = 5;
@@ -118,7 +123,8 @@ class HeiseBridge extends FeedExpander
     protected function parseItem($feedItem)
     {
         $item = parent::parseItem($feedItem);
-
+        $sessioncookie=$this->getInput('sessioncookie');
+        
         // strip rss parameter
         $item['uri'] = explode('?', $item['uri'])[0];
 
@@ -128,14 +134,16 @@ class HeiseBridge extends FeedExpander
         }
 
         // abort on heise+ articles and link to archive.ph for full-text content
-        if (str_starts_with($item['title'], 'heise+ |')) {
+        if ($sessioncookie == "" && str_starts_with($item['title'], 'heise+ |')) {
             $item['uri'] = 'https://archive.ph/?run=1&url=' . urlencode($item['uri']);
             return $item;
         }
 
         $item['uri'] .= '?seite=all';
-        $article = getSimpleHTMLDOMCached($item['uri']);
-
+        $article = getSimpleHTMLDOM($item['uri'], [
+            'cookie: ssohls='.$sessioncookie
+        ]);
+        
         if ($article) {
             $article = defaultLinkTo($article, $item['uri']);
             $item = $this->addArticleToItem($item, $article);


### PR DESCRIPTION
If you enter a valid sessioncookie, you can get the full heise+ (paywall) articles.